### PR TITLE
[ch6597] [ch6596] Bank merchant narrative & receipt changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bank-test-api-visualizer",
-  "version": "1.0.1",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bank-test-api-visualizer",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Web app calling the bank test api",
   "main": "src/index.js",
   "engines": {

--- a/src/app/util/external-api.js
+++ b/src/app/util/external-api.js
@@ -84,7 +84,7 @@ const handleCreateBankTransaction = async (
         scheme: 'VISA'
       },
       merchant: {
-        name: merchantItem.label
+        transactionNarrative: merchantItem.label
       }
     }
   ];

--- a/src/public/js/api.js
+++ b/src/public/js/api.js
@@ -285,10 +285,6 @@ const renderReceipt = (receipt) => {
   const headerFragment = document.createDocumentFragment();
   const headerDiv = headerFragment.appendChild(document.createElement('div'));
   headerDiv.className = 'receipt-header';
-  const merchantLogo = headerDiv.appendChild(document.createElement('img'));
-  merchantLogo.className = 'receipt-merchant-logo';
-  merchantLogo.alt = 'merchant logo';
-  merchantLogo.src = receipt.merchant.logoUrl;
 
   const merchantDetails = headerDiv.appendChild(document.createElement('p'));
   merchantDetails.textContent = receipt.merchant.name;


### PR DESCRIPTION
- Changes `merchant.name` -> `merchant.transactionNarrative`
- Removes `merchant.logoUrl` from receipt response

[ch6597] [ch6596]