### PR TITLE
Failed account and receipt creation still registered as successful

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ typings/
 # End of https://www.gitignore.io/api/node
 
 *.env
+.configure.sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -443,6 +443,12 @@
         "esutils": "^2.0.2"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true
+    },
     "dtrace-provider": {
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "node": ">12.0.0"
   },
   "scripts": {
+    "start:development": "[ ! -f .development.env ] && ./.configure.sh; cp .development.env .env && node -r dotenv/config src/index.js",
+    "start:preprod": "[ ! -f .preprod.env ] && ./.configure.sh; cp .preprod.env .env && node -r dotenv/config src/index.js",
     "start": "node src/index.js",
     "lint": "eslint src; exit 0",
     "lint:fix": "eslint src --fix; exit 0"
@@ -21,6 +23,7 @@
     "uuidv4": "^6.0.6"
   },
   "devDependencies": {
+    "dotenv": "^8.2.0",
     "eslint": "^6.8.0",
     "eslint-config-standard": "^14.1.1",
     "eslint-plugin-import": "^2.20.2",

--- a/src/app/util/external-api.js
+++ b/src/app/util/external-api.js
@@ -40,10 +40,15 @@ const handleCreateAccount = async (
       JSON.stringify({ email: requestHandler.body.email })
     );
     log('debug', 'result from creating account: ', result);
+    if (isSuccessfulResponse(result.statusCode)) {
+      responseHandler.sendStatus(204);
+    } else {
+      responseHandler.sendStatus(result.statusCode);
+    }
   } catch (error) {
     log('error', 'failed to create account', error);
+    responseHandler.sendStatus(500);
   }
-  responseHandler.sendStatus(204);
 };
 
 const handleCreateBankTransaction = async (
@@ -94,11 +99,16 @@ const handleCreateBankTransaction = async (
       headerProps,
       JSON.stringify(body)
     );
-    log('debug', 'result from creating bank transaction: ', result);
+    log('debug', 'result from creating bank transaction: ', {body: JSON.stringify(body), result});
+    if (isSuccessfulResponse(result.statusCode)) {
+      responseHandler.sendStatus(204);
+    } else {
+      responseHandler.sendStatus(result.statusCode);
+    }
   } catch (error) {
     log('error', 'failed to bank transaction', error);
+    responseHandler.sendStatus(500);
   }
-  responseHandler.sendStatus(204);
 };
 
 const handleGetReceipt = async (


### PR DESCRIPTION
* Fix issue where failed account and receipt creation still registered as successful
* load config from .env file so that we can just do `npm run start:development` or preprod for the right settings for convenience.